### PR TITLE
"release(version): 0.4.2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+#### 0.4.2 (2022-01-08)
+
+##### New Features
+
+- **release-patch:** scripts to automatize release (#73) (2bb7d002)
+- **changelog:** added changelog file (#72) (d0f8c165)
+- **prettier-tab-width:** tab width update (#71) (f220ed41)
+- **readme-monorepo:** update with new partial example (#68) (51fa1453)
+
+##### Bug Fixes
+
+- **prettier-types:** fixing prettier tab width and restore config type (#70) (c8197fe8)
+
+#### 0.4.1 (2022-01-08)
+
+##### New Features
+
+- **release-patch:** scripts to automatize release (#73) (2bb7d002)
+- **changelog:** added changelog file (#72) (d0f8c165)
+- **prettier-tab-width:** tab width update (#71) (f220ed41)
+- **readme-monorepo:** update with new partial example (#68) (51fa1453)
+
+##### Bug Fixes
+
+- **prettier-types:** fixing prettier tab width and restore config type (#70) (c8197fe8)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-partial-dumper",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A package to help mongoose users to partially dump models of your db",
   "main": "build/index.cjs.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- release(0.3.1): readme
- fix(npm-ignore): removing node_modules from npmignore
- release(0.3.2): fixes npm ignore
- feat(rollup-typescript): added rollup to build, fixed babel conflict, exporting dumper, restore and anonymize utils
- feat(rollup-typescript): babel update
- feat(npm-ignore): removing tslint and added rollup configs
- release(0.4.0): rollup, exports, fixes
- fix(typescript-declaration-files): fixed type checking on builded package
- release(0.4.1): fixed typescript declaration files
- feat(readme-monorepo): update with new partial example (#68)
- fix(prettier-types): fixing prettier tab width and restore config type (#70)
- feat(prettier-tab-width): tab width update (#71)
- feat(changelog): added changelog file (#72)
- feat(release-patch): scripts to automatize release (#73)
- release(version): 0.4.2
