### PR TITLE
fix(release-typo): removing git function wrong usage

### DIFF
--- a/scripts/release/release-patch.js
+++ b/scripts/release/release-patch.js
@@ -39,7 +39,7 @@ const writeFile = util.promisify(fs.writeFile);
     await git.add(['package.json', 'CHANGELOG.md']);
     await git.commit(`release(version): ${newVersion}`);
     await git.addAnnotatedTag(newVersion, `release(version): ${newVersion}`);
-    await git().push(['--follow-tags', '-u', 'origin', branchName]);
+    await git.push(['--follow-tags', '-u', 'origin', branchName]);
 
     const { spawn } = childProcess;
     const gh = spawn('gh', [


### PR DESCRIPTION
ref https://github.com/Streeterxs/mongoose-partial-dump/issues/66
- fix(release-typo): removing git function wrong usage
