### PR TITLE
"release(version): 0.4.4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+#### 0.4.2 (2022-01-08)
+
+##### Bug Fixes
+
+- **release-typo:** removing git function wrong usage (#83) (53a61289)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-partial-dumper",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "A package to help mongoose users to partially dump models of your db",
   "main": "build/index.cjs.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
#### 0.4.2 (2022-01-08)

##### Bug Fixes

* **release-typo:**  removing git function wrong usage (#83) (53a61289)

