### PR TITLE
fix(circleci-filter-typo): fixed typo branchs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,6 @@ workflows:
             filters:
               tags:
                 only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-              branchs:
+              branches:
                 only: /^feature\/\.*/
             


### PR DESCRIPTION
ref: https://github.com/Streeterxs/mongoose-partial-dump/issues/66
- fix(circleci-filter-typo): fixed typo branchs
