### PR TITLE
feat(circleci-defaults): added default options for jobs like working_directory and executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,16 @@
 version: 2.1
+
+defaults: &defaults
+  working_directory: ~/mongoose-partial-dump
+  executor:
+    name: node/default
+    tag: 'lts'
+    
 orbs:
   node: circleci/node@4.5.1
 jobs:
   build-and-test:
-    executor:
-      name: node/default
-      tag: 'lts'
+    <<: *defaults
     steps:
       - checkout
       - node/install-packages:
@@ -17,10 +22,11 @@ jobs:
       - run:
           command: yarn build
   deploy:
+    <<: *defaults
     steps:
       - run:
           name: Authenticate npm registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/mongoose-partial-dump/.npmrc
       - run:
           name: Publish package
           command: npm publish


### PR DESCRIPTION
ref: https://github.com/Streeterxs/mongoose-partial-dump/issues/66
- feat(circleci-defaults): added default options for jobs like working_directory and executor
