### PR TITLE
feat(circleci-continue-on-build-error): build workflow should give us a typescript error and continue to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
 orbs:
   node: circleci/node@4.5.1
 jobs:
-  build-and-test:
+  install-and-test:
     <<: *defaults
     steps:
       - checkout
@@ -19,6 +19,10 @@ jobs:
           command: yarn install
       - run:
           command: yarn jest
+  build:
+    <<: *defaults
+    steps:
+      - checkout
       - run:
           command: yarn build
   deploy:
@@ -33,10 +37,14 @@ jobs:
 workflows:
     build-and-test:
       jobs:
-        - build-and-test
-        - deploy:
+        - install-and-test
+        - build:
             requires:
-              - build-and-test
+              - install-and-test
+        - deploy:
+            type: approval
+            requires:
+              - install-and-test
             filters:
               tags:
                 only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/


### PR DESCRIPTION
ref: https://github.com/Streeterxs/mongoose-partial-dump/issues/66
- feat(circleci-continue-on-build-error): build workflow should give us a typescript error and continue to deploy
