### PR TITLE
fix(circleci): fixing executor node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   working_directory: ~/mongoose-partial-dumper
   executor:
     name: node/default
-    tag: 'lts'
+    tag: '16.19'
     
 orbs:
   node: circleci/node@4.5.1


### PR DESCRIPTION
- release(0.3.1): readme
- fix(npm-ignore): removing node_modules from npmignore
- release(0.3.2): fixes npm ignore
- feat(rollup-typescript): added rollup to build, fixed babel conflict, exporting dumper, restore and anonymize utils
- feat(rollup-typescript): babel update
- feat(npm-ignore): removing tslint and added rollup configs
- release(0.4.0): rollup, exports, fixes
- fix(typescript-declaration-files): fixed type checking on builded package
- release(0.4.1): fixed typescript declaration files
- feat(readme-monorepo): update with new partial example (#68)
- fix(prettier-types): fixing prettier tab width and restore config type (#70)
- feat(prettier-tab-width): tab width update (#71)
- feat(changelog): added changelog file (#72)
- feat(release-patch): scripts to automatize release (#73)
- feat(release-patch-pull-request): added pull request feature to release-patch script (#78)
- release(version): 0.4.2 (#79)
- feat(release-patch-script-tag): add new tag to new release commit (#80)
- release(version): 0.4.2 (#81)
- fix(release): fixed release script to push with tag, and removed old changelog (#82)
- fix(release-typo): removing git function wrong usage (#83)
- fix(package-version): fixed wrong version of package (#85)
- release(version): 0.4.2 (#86)
- feat(create-pull-request): function to create a new pull request (#89)
- feat(create-release): script to create release after new tag creation (#90)
- feat(automatize-deploy): job to automatize package deploy to npm (#91)
- fix(circleci-filter-typo): fixed typo branchs (#93)
- feat(circleci-defaults): added default options for jobs like working_directory and executor (#95)
- feat(circleci-continue-on-build-error): build workflow should give us a typescript error and continue to deploy (#97)
- fix(circleci-deploy-workflow): fixed branch regex (#99)
- feat(circleci-hold-deploy): holding deploy workflow (#101)
- feat(filter-deploy-workflows): filtering by semver regex tag version and branch initial release naming (#103)
- fix(removing-tag-validation): removed tag validation not permitting release (#105)
- fix(circleci-build-job): fixing broken build job (#107)
- fix(build-and-deploy): removed tsc generation to properly deploy (#108)
- release(version): 0.4.3 (#110)
- feat(eslint): added no-unused-expressions rule (#111)
- feat(chunk-restore): added insertMany docs in restore by chunk (#112)
- fix(circleci): fixing executor node version
